### PR TITLE
fix pool.Get,GetCtx to return []Vertex, to match client.Get,GetCtx

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -382,7 +382,7 @@ func (p *Pool) AddVertexCtx(ctx context.Context, label string, i interface{}, bi
 }
 
 // Get
-func (p *Pool) Get(query string, bindings, rebindings map[string]string) (resp interface{}, err error) {
+func (p *Pool) Get(query string, bindings, rebindings map[string]string) (resp []graphson.Vertex, err error) {
 	var pc *conn
 	if pc, err = p.conn(); err != nil {
 		return resp, errors.Wrap(err, "Failed p.conn")
@@ -392,7 +392,7 @@ func (p *Pool) Get(query string, bindings, rebindings map[string]string) (resp i
 }
 
 // GetCtx
-func (p *Pool) GetCtx(ctx context.Context, query string, bindings, rebindings map[string]string) (resp interface{}, err error) {
+func (p *Pool) GetCtx(ctx context.Context, query string, bindings, rebindings map[string]string) (resp []graphson.Vertex, err error) {
 	var pc *conn
 	if pc, err = p.connCtx(ctx); err != nil {
 		return resp, errors.Wrap(err, "GetCtx: Failed p.connCtx")


### PR DESCRIPTION
sync the return types, rather than downgrade them