### PR TITLE
Updatedgraphsondependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 
 .PHONY: test-bench
 test-bench:
-	@go test -bench=. -race
+	@go test -v -bench=. -race
 
 .PHONY: gremlin
 gremlin:

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 	"github.com/pkg/errors"
 )
 

--- a/examples/cursor/main.go
+++ b/examples/cursor/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/ONSdigital/graphson"
 	"github.com/ONSdigital/gremgo-neptune"
-	"github.com/gedge/graphson"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/ONSdigital/gremgo-neptune
 
 require (
-	github.com/gedge/graphson v0.0.0-20190531092426-d39cb8fe4384
+	github.com/ONSdigital/graphson v0.0.0-20190531092426-d39cb8fe4384
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gorilla/websocket v1.4.0
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/ONSdigital/gremgo-neptune
 
 require (
-	github.com/ONSdigital/graphson v0.0.0-20190531092426-d39cb8fe4384
+	github.com/ONSdigital/graphson v0.0.0-20190717101729-324718b3a644
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gorilla/websocket v1.4.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/gedge/graphson v0.0.0-20190531092426-d39cb8fe4384 h1:WnFZkCrqH8PJFxQtp3EG0GKcEneNwqS3hzYDr6d7ctE=
-github.com/gedge/graphson v0.0.0-20190531092426-d39cb8fe4384/go.mod h1:Ehgz7wAEVmSkFMIY2WFsi33IZXvzrgBVsro51AEIkq0=
+github.com/ONSdigital/graphson v0.0.0-20190531092426-d39cb8fe4384 h1:tQOaBPntKLKJZYNTqT6YwE9fXZZLD0jBrke18nAJV5w=
+github.com/ONSdigital/graphson v0.0.0-20190531092426-d39cb8fe4384/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ONSdigital/graphson v0.0.0-20190531092426-d39cb8fe4384 h1:tQOaBPntKLKJZYNTqT6YwE9fXZZLD0jBrke18nAJV5w=
 github.com/ONSdigital/graphson v0.0.0-20190531092426-d39cb8fe4384/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
+github.com/ONSdigital/graphson v0.0.0-20190717101729-324718b3a644 h1:qlXGwzq+X2DUd0iOYmkXwnSxYDeU1efFwp7sUXASjO0=
+github.com/ONSdigital/graphson v0.0.0-20190717101729-324718b3a644/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/pool.go
+++ b/pool.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 	"github.com/pkg/errors"
 )
 

--- a/pool_dial_test.go
+++ b/pool_dial_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
There's a new fix in graphson (for parsing int64), so gremgo should update its go.mod dependency to the newer version.

To review, please rebuild gremgo making sure that the go command is configured to use module mode.  I.e. either building it in a place that is outside of GOPATH, or with export GO111MODULE=on. Then run the unit tests.