### PR TITLE
Add ability to configure TLS connection in websocket Dialer

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -1,42 +1,53 @@
 package gremgo
 
-import "time"
+import (
+	"crypto/tls"
+	"time"
+)
 
-//DialerConfig is the struct for defining configuration for WebSocket dialer
+// DialerConfig is the struct for defining configuration for WebSocket dialer
 type DialerConfig func(*Ws)
 
-//SetAuthentication sets on dialer credentials for authentication
+// SetAuthentication sets on dialer credentials for authentication
 func SetAuthentication(username string, password string) DialerConfig {
 	return func(c *Ws) {
 		c.auth = &auth{username: username, password: password}
 	}
 }
 
-//SetTimeout sets the dial timeout
+// SetTimeout sets the dial timeout
 func SetTimeout(seconds int) DialerConfig {
 	return func(c *Ws) {
 		c.timeout = time.Duration(seconds) * time.Second
 	}
 }
 
-//SetPingInterval sets the interval of ping sending for know is
-//connection is alive and in consequence the client is connected
+// SetPingInterval sets the interval of ping sending for know is
+// connection is alive and in consequence the client is connected
 func SetPingInterval(seconds int) DialerConfig {
 	return func(c *Ws) {
 		c.pingInterval = time.Duration(seconds) * time.Second
 	}
 }
 
-//SetWritingWait sets the time for waiting that writing occur
+// SetWritingWait sets the time for waiting that writing occur
 func SetWritingWait(seconds int) DialerConfig {
 	return func(c *Ws) {
 		c.writingWait = time.Duration(seconds) * time.Second
 	}
 }
 
-//SetReadingWait sets the time for waiting that reading occur
+// SetReadingWait sets the time for waiting that reading occur
 func SetReadingWait(seconds int) DialerConfig {
 	return func(c *Ws) {
 		c.readingWait = time.Duration(seconds) * time.Second
+	}
+}
+
+// SetTLSClientConfig sets the TLS client config for the
+// underlying websocket connection
+func SetTLSClientConfig(conf *tls.Config) DialerConfig {
+	return func(c *Ws) {
+		c.tlsConfig = conf
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -2,6 +2,7 @@ package gremgo
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"sync"
 	"time"
@@ -44,10 +45,11 @@ type Ws struct {
 	readingWait  time.Duration
 	timeout      time.Duration
 	quit         chan struct{}
+	tlsConfig    *tls.Config
 	sync.RWMutex
 }
 
-//Auth is the container for authentication data of dialer
+// Auth is the container for authentication data of dialer
 type auth struct {
 	username string
 	password string
@@ -63,6 +65,11 @@ func (ws *Ws) connectCtx(ctx context.Context) (err error) {
 		ReadBufferSize:   512 * 1024,
 		HandshakeTimeout: 5 * time.Second, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}
+
+	if ws.tlsConfig != nil {
+		d.TLSClientConfig = ws.tlsConfig
+	}
+
 	ws.conn, _, err = d.DialContext(ctx, ws.host, http.Header{})
 	if err != nil {
 		return


### PR DESCRIPTION
Add ability to provide a full TLSConfig object through for the websocket connection

The `make test` target is failing for benchmarks on master as well as this branch, but the  unit tests themselves pass